### PR TITLE
Fix sign error and threshold values in PCP algorithm

### DIFF
--- a/r_pca.py
+++ b/r_pca.py
@@ -62,9 +62,9 @@ class R_pca:
         #located in the table on page 29 of https://arxiv.org/pdf/0912.3599.pdf
         while (err > _tol) and iter < max_iter:
             Lk = self.svd_threshold(
-                self.D - Sk + self.mu_inv * Yk, self.mu_inv)                            #this line implements step 3
+                self.D - Sk - self.mu_inv * Yk, self.mu)                                #this line implements step 3
             Sk = self.shrink(
-                self.D - Lk + (self.mu_inv * Yk), self.mu_inv * self.lmbda)             #this line implements step 4
+                self.D - Lk + self.mu_inv * Yk, self.lmbda * self.mu)                   #this line implements step 4
             Yk = Yk + self.mu * (self.D - Lk - Sk)                                      #this line implements step 5
             err = self.frobenius_norm(self.D - Lk - Sk)
             iter += 1


### PR DESCRIPTION
- Fix sign error in L update: use (M - S - μ⁻¹Y) instead of (M - S + μ⁻¹Y)
- Fix L threshold: use μ instead of μ⁻¹
- Fix S threshold: use λμ instead of λ/μ

These corrections align with Algorithm 1 (Principal Component Pursuit by Alternating Directions) on page 29 of https://arxiv.org/pdf/0912.3599.pdf

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)